### PR TITLE
Add onPaste callback to editor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.intception/om-ace "0.1.9"
+(defproject org.clojars.intception/om-ace "0.1.10"
   :description "An Om (ClojureScript) ace component"
   :url "http://github.com/intception/om-ace"
   :license {:name "Eclipse"

--- a/src/om_ace/core.cljs
+++ b/src/om_ace/core.cljs
@@ -40,7 +40,8 @@
             ace-edit-session (.-EditSession (.require js/ace "ace/edit_session"))
             ace-undo-manager (.-UndoManager (.require js/ace "ace/undomanager"))
             ace-session (ace-edit-session. (or cursor-val ""))
-            ace-undo (ace-undo-manager.)]
+            ace-undo (ace-undo-manager.)
+            on-paste (om/get-state owner :onPaste)]
 
         ;; set session and attach undo manager
         (.. ace-instance (setSession ace-session))
@@ -52,6 +53,11 @@
         ;; update om/cursor when the editor changes
         (.. ace-session
             (on "change" #(om/update! cursor (:ks state) (.getValue ace-instance))))
+
+        ; if on-paste callback fn exists, apply it. fn is called with the pasted text as its argument
+        (.. ace-instance
+            (on "paste" #(when on-paste
+                           (on-paste (get (js->clj %) "text")))))
 
         ;https://github.com/ajaxorg/ace/wiki/Configuring-Ace#editor-options
         ;https://github.com/ajaxorg/ace/wiki/Configuring-Ace#session-options


### PR DESCRIPTION
- Se agrega la posibilidad de agregar funcion onPaste al editor, el cual se va a ejecutar con el texto pegado como argumento de la funcion.
- Maquinaria necesaria para https://github.com/prismacampaigns/prisma/issues/2987